### PR TITLE
fix ubuntu chrome keyring request

### DIFF
--- a/systems/__init__.py
+++ b/systems/__init__.py
@@ -31,6 +31,7 @@ class BaseSystem(metaclass=ABCMeta):
             self.browser_path,
             '--no-first-run',
             '--disable-pinch',
+            '--password-store=basic',
             '--user-data-dir={}'.format(user_dir),
             '--window-size={},{}'.format(display['width'], display['height']),
             '--window-position={},{}'.format(display['x'], display['y']),


### PR DESCRIPTION
Tested on Ubuntu 20.04, Chrome will ask for the keyring to be opened unless this flag is passed.

This line made the difference between being able to run on startup, and not.

More info here https://dev.to/rahedmir/how-to-fix-google-chrome-chromium-asks-for-password-to-unlock-keyring-in-linux-1dl0